### PR TITLE
Fix tests to pass with current and future releases of DateTime::Locale

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for DateTimeX-Web
 
+  - fixed tests and code to work with upcoming DateTime::Locale (currently in
+    trial releases) (DROLSKY++)
+
 0.06 2015/03/30
   - fixed a test to support newer DateTime::Format::Mail (SREZIC++)
 

--- a/lib/DateTimeX/Web.pm
+++ b/lib/DateTimeX/Web.pm
@@ -46,7 +46,7 @@ sub new {
   }, $class;
 
   $self->time_zone( $config{time_zone} || delete $config{timezone} || 'UTC' );
-  $self->locale( $config{locale} || 'en_us' );
+  $self->locale( $config{locale} || 'en-US' );
 
   $self;
 }
@@ -89,7 +89,7 @@ sub locale {
 
   if ( $locale ) {
     $self->{config}->{locale} =
-      ( blessed $locale && $locale->isa('DateTime::Locale::root') ) 
+      ( blessed $locale && ($locale->isa('DateTime::Locale::root') || $locale->isa('DateTime::Locale::FromData') ) ) 
         ? $locale
         : DateTime::Locale->load( $locale );
   }

--- a/t/constructor.t
+++ b/t/constructor.t
@@ -9,12 +9,11 @@ use DateTimeX::Web;
   ok $dtx->time_zone->isa('DateTime::TimeZone');
   is $dtx->time_zone->name => 'UTC';
 
-  ok $dtx->locale->isa('DateTime::Locale::root');
-  is $dtx->locale->name => 'English';
+  is $dtx->locale->id => 'en-US';
 
   my $dt = $dtx->now;
   is $dt->time_zone->name => 'UTC';
-  is $dt->locale->name    => 'English';
+  is $dt->locale->id      => 'en-US';
 }
 
 { # let's replace the time_zone and the locale (with other objects)
@@ -25,8 +24,7 @@ use DateTimeX::Web;
   is $dtx->time_zone->name => 'Asia/Tokyo';
 
   $dtx->locale(DateTime::Locale->load('ja'));
-  ok $dtx->locale->isa('DateTime::Locale::ja');
-  is $dtx->locale->name => 'Japanese';
+  is $dtx->locale->id => 'ja';
 
   my $dt = $dtx->now;
   is $dt->time_zone->name => 'Asia/Tokyo';
@@ -41,8 +39,7 @@ use DateTimeX::Web;
   is $dtx->time_zone->name => 'Asia/Tokyo';
 
   $dtx->locale('ja');
-  ok $dtx->locale->isa('DateTime::Locale::ja');
-  is $dtx->locale->name => 'Japanese';
+  is $dtx->locale->id => 'ja';
 
   my $dt = $dtx->now;
   is $dt->time_zone->name => 'Asia/Tokyo';
@@ -75,18 +72,18 @@ use DateTimeX::Web;
 
 { # provide a default locale
   my $dtx = DateTimeX::Web->new( locale => 'ja' );
-  is $dtx->locale->name => 'Japanese';
+  is $dtx->locale->id => 'ja';
 
   my $dt = $dtx->now;
-  is $dt->locale->name => 'Japanese';
+  is $dt->locale->id => 'ja';
 }
 
 { # should accept a locale object, too.
   my $dtx = DateTimeX::Web->new( locale => DateTime::Locale->load('ja') );
-  is $dtx->locale->name => 'Japanese';
+  is $dtx->locale->id => 'ja';
 
   my $dt = $dtx->now;
-  is $dt->locale->name => 'Japanese';
+  is $dt->locale->id => 'ja';
 }
 
 { # you can pass a hash reference
@@ -95,8 +92,7 @@ use DateTimeX::Web;
   ok $dtx->time_zone->isa('DateTime::TimeZone');
   is $dtx->time_zone->name => 'Asia/Tokyo';
 
-  ok $dtx->locale->isa('DateTime::Locale::ja');
-  is $dtx->locale->name => 'Japanese';
+  is $dtx->locale->id => 'ja';
 
   my $dt = $dtx->now;
   is $dt->time_zone->name => 'Asia/Tokyo';


### PR DESCRIPTION
There are a couple fixes in here ...
- Future version of DT::Locale don't like `en_us` as a locale code so use `en-US`.
- Don't check the class of a locale object, just check it's `->id`
- Don't check the locale object's `->name`, this is much more likely to change between DT::Locale releases than the id.
